### PR TITLE
A fix of RWD issue in dashboard page

### DIFF
--- a/web/src/pug/dashboard/index.pug
+++ b/web/src/pug/dashboard/index.pug
@@ -14,70 +14,70 @@ block body
       p.text-center#loading-text: :i18n dashboard:loading
     .container.py-4
       .row
-        .col-4.p-2: .card#slack-users
+        .col-12.col-sm-6.col-lg-4.p-2: .card#slack-users
           .card-body.text-center
             p.card-text
               span 0
               a(style='font-size: 2em;') +
               br
               a(href='https://join.g0v.tw/', target='_blank'): :i18n dashboard:slack_user
-        .col-4.p-2: .card#slack-channels
+        .col-12.col-sm-6.col-lg-4.p-2: .card#slack-channels
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_1
               br
               :i18n dashboard:slack_channels
-        .col-4.p-2: .card#slack-messages
+        .col-12.col-sm-6.col-lg-4.p-2: .card#slack-messages
           .card-body.text-center
             p.card-text
               span 0
               a(style='font-size: 2em;') +
               br
               a(href='https://g0v-slack-archive.g0v.ronny.tw/', target='_blank'): :i18n dashboard:slack_message
-        .col-4.p-2: .card#summit-count
+        .col-12.col-sm-6.col-lg-4.p-2: .card#summit-count
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_2
               br
               a(href='https://summit.g0v.tw/', target='_blank'): :i18n dashboard:summit
-        .col-4.p-2: .card#hackathon-count
+        .col-12.col-sm-6.col-lg-4.p-2: .card#hackathon-count
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_2
               br
               a(href='https://jothon.g0v.tw/events/', target='_blank'): :i18n dashboard:hackathon
-        .col-4.p-2: .card#hackathon-proposals
+        .col-12.col-sm-6.col-lg-4.p-2: .card#hackathon-proposals
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_1
               br
               a(href='https://docs.google.com/spreadsheets/d/1C9-g1pvkfqBJbfkjPB0gvfBbBxVlWYJj6tTVwaI5_x8/', target='_blank'): :i18n dashboard:proposal
-        .col-4.p-2: .card#fanpage-like
+        .col-12.col-sm-6.col-lg-4.p-2: .card#fanpage-like
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_3
               br
               a(href='https://www.facebook.com/g0v.tw', target='_blank'): :i18n dashboard:likes
-        .col-4.p-2: .card#fanpage-follow
+        .col-12.col-sm-6.col-lg-4.p-2: .card#fanpage-follow
           .card-body.text-center
             p.card-text
               span 0
               :i18n dashboard:quantifier_3
               br
               a: :i18n dashboard:follows
-        .col-4.p-2: .card#github-repos
+        .col-12.col-sm-6.col-lg-4.p-2: .card#github-repos
           .card-body.text-center
             p.card-text
               span 0
               a(style='font-size: 2em;') +
               br
               a(href='https://github.com/g0v', target='_blank'): :i18n dashboard:repo
-        .col-4.p-2: .card#10th-count
+        .col-12.col-sm-6.col-lg-4.p-2: .card#10th-count
           .card-body.text-center
             p.card-text
               span 1


### PR DESCRIPTION
In dashboard page, cards uses 1/3 of available width(defined by grid container) for all device width. When visiting this page using a device with small viewport width, it is hard to read the numbers, since the numbers are presented vertically.

This PR fixes this issue by setting proper value for grid columns in different device width.