### PR TITLE
Fix: hover effect box model alignment

### DIFF
--- a/web/src/styl/g0vernance.styl
+++ b/web/src/styl/g0vernance.styl
@@ -1,8 +1,9 @@
-[data-black]:hover
+[data-black]
+  display: inline-block
   position: relative
-  &:after
+  &:hover::after
     content: attr(data-black)
-    background: black
+    background: #222324
     color: white
     position: absolute
     top: 0


### PR DESCRIPTION
This patch fixes incorrect text alignment. As `<span>` is inferred as `display: inline`, the `width` and `height` specification has no effect on the pseudo-element and thus the hover effect would not align properly.

Adding `display: inline-block` would fix the issue.

Before this patch:
<img width="223" alt="Before this patch" src="https://github.com/user-attachments/assets/e57d7d1d-9831-4462-b25f-67f0f3cbd43e">

After this patch:
<img width="234" alt="After this patch" src="https://github.com/user-attachments/assets/04726b77-7709-47e4-9d6d-51851fd8fcaf">

 (This patch also updates the pure black color to match the body text color.)