### PR TITLE
[g0v infrath25n] 首頁內容、結構調整

### DIFF
--- a/web/locales/en/index.yaml
+++ b/web/locales/en/index.yaml
@@ -44,7 +44,7 @@ grantsDescription: 'Organized by <a href="https://jothon.g0v.tw" target="_blank"
 
 ## How to Join
 getInvolved_title: "How to get involved?"
-getInvolved_description: 'The best way to get to know g0v is to come participate. Whether online or offline, there are many channels to interact with members of the community. If you would like to learn more about open-source collaboration, you can take a look at <a href="https://g0v.hackmd.io/@jothon/g0v-cowork-guideline" target="_blank">g0v open-source collaboration guide</a>.'
+getInvolved_description: 'The best way to get to know g0v is to come participate. Whether online or offline, there are many channels to interact with members of the community.'
 
 ## Offline
 events: "Offline: Bimonthly g0v hackathons and smaller community hackathons"
@@ -79,6 +79,6 @@ organize: "Organize Related Events"
 organizeBlurb: "Currently, g0v hackathons only take place in Taiwan, but civic hackers in other countries are beginning to take notice. Does your country have a g0v movement? Why not consider starting a g0v hackathon where you are?"
 organizeLink: "Organize"
 moreInfo: "More information"
-callToAction: 'If you want to participate in g0v, but are unsure how, check out our'
+callToAction: 'If you want to participate in g0v, but are unsure how, check out our Newcomers Guide'
 newcomersGuideLinkText: 'Newcomers Guide'
 baam: '!'

--- a/web/locales/ja/index.yaml
+++ b/web/locales/ja/index.yaml
@@ -80,6 +80,7 @@ organize: "関連するイベントを始める"
 organizeBlurb: "現在、g0v ハッカソンは台湾を中心に開催されていますが、海外のいくつかの国が注目し始めています。あなたの国にまだありませんか？ あなたの国で g0v ハッカソンを始めることを考えてみませんか？"
 organizeLink: "今すぐ始める"
 moreInfo: "もっと詳しく"
-callToAction: "g0v に参加したいけど、どうすればいいのかわからないという方は、こちらをご覧ください："
+callToAction: "g0v に参加したいけど、どうすればいいのかわからないという方は、こちらをご覧ください"
 newcomersGuideLinkText: 'ビギナーズガイド'
 baam: '。'
+qandaIntro: ""

--- a/web/locales/zh-TW/index.yaml
+++ b/web/locales/zh-TW/index.yaml
@@ -44,7 +44,7 @@ grantsDescription: '由「<a href="https://jothon.g0v.tw" target="_blank">g0v �
 
 # How to Join
 getInvolved_title: "如何參與？"
-getInvolved_description: '了解 g0v 最快的方式就是實際來參與一次。無論線上或線下，你都可以找得到各種管道與社群參與者互動。想要更了解開源協作的模式，可以參考 <a href="https://g0v.hackmd.io/@jothon/g0v-cowork-guideline" target="_blank">g0v 開源協作手冊</a>。'
+getInvolved_description: '了解 g0v 最快的方式就是實際來參與一次。無論線上或線下，你都可以找得到各種管道與社群參與者互動。'
 
 ## Offline
 events: "線下：大小黑客松雙月黑客松與社群小松"
@@ -79,6 +79,6 @@ organize: "發起相關活動"
 organizeBlurb: "目前 g0v 黑客松主要仍在台灣舉行，但海外已有若干國家響應。在你的國家沒有嗎？何不考慮在你的國家發起 g0v 黑客松呢？"
 organizeLink: "現在就發起"
 moreInfo: "更多資訊"
-callToAction: '若你想參與 g0v 卻仍不得其門而入，就來看看'
+callToAction: '若你想參與 g0v 卻仍不得其門而入，就來看看新手指南'
 newcomersGuideLinkText: '新手指南'
 baam: '！'

--- a/web/src/pug/index.pug
+++ b/web/src/pug/index.pug
@@ -62,93 +62,24 @@ block body
           a(href=intlbase("/manifesto/" + i18n.language())): :i18n index:g0vManifesto_link
           :i18n index:g0vManifesto_description2
 
-        h3: :i18n index:g0vManySides_title
-        p: :i18n index:g0vManySides_description
-        .text-center.my-4.py-4
-          a.btn.btn-outline-danger.mr-2.mb-2(href=intlbase("event/")): :i18n index:eventInfo
-          a.btn.btn-outline-danger.mr-2.mb-2(href=intlbase("novice/")): :i18n index:newcomersGuide
-          a.btn.btn-outline-danger.mb-2(href=intlbase("faq/")): :i18n index:faq
-        .text-center.text-sm.text-muted OSDC 2013 Keynote 「g0v 黑客松 - 寫程式改造社會」 by Kirby
-        .w-100.mb-4.mt-1
-          .aspect-ratio(style="padding-top:75%"): .w-100.h-100: iframe.w-100.h-100(src="https://www.youtube.com/embed/0HURMy0l4Ck")
-
-      .typeset.heading-contrast.pt-4
-        h2#projects.m-0: :i18n index:portfolio
-        hr
-        p
-          :i18n index:portfolioData
-          | 
-          :i18n index:portfolioMoreData
-          | 
-          a(href=intlbase("dashboard/")): :i18n index:dashboardLinkText
-          | 
-          :i18n index:awesomeProjects
-        p
-          :i18n index:famousProjects
-        include modules/project.pug
-
-        p
-          :i18n index:hackathonRecords
-              
-        h3
-          :i18n index:grantsTitle
-        p
-          :i18n index:grantsDescription
-
-      .typeset.heading-contrast.pt-4
-        h2#participate.m-0: :i18n index:getInvolved_title
-        hr
-        p: :i18n index:getInvolved_description
-        h3: :i18n index:events
-        h4: :i18n index:hackathons
-        p: :i18n index:eventsBlurb
-        p: :i18n index:eventsBlurbCont
-          a(href="https://jothon.g0v.tw/" target="_blank"): :i18n index:jothonWebsite
-          t: :i18n index:jothonFollow
-            a(href="http://g0v-jothon.kktix.cc" target="_blank"): :i18n index:jothonLink
-            t: :i18n index:jothonEventInfo
-        h4: :i18n index:otherHackathons
-        p: :i18n index:infraHackathons
-        p: :i18n index:smallHackathons
-
-        h3: :i18n index:onlinePlatform
-        p: :i18n index:onlinePlatformBlurb
-        ul
-          li: a(href="https://www.facebook.com/groups/g0v.general/" target="_blank"): :i18n index:g0vFacebook
-          li: a(href="https://join.g0v.tw" target="_blank"): :i18n index:g0vSlack
-          li: a(href="https://g0v.hackmd.io/NuhdUaTVRNykTqcstpM8VQ?view", target="_blank") g0v Slack Channels
-        p: :i18n index:codeOfConduct
-        h3: :i18n index:otherChannels
-        p: :i18n index:participateMore
         .row
+          .col-md-4: .card.shadow-sm.mb-4.h-100: .card-body
+            h4.text-center: :i18n index:eventInfo
+            p: :i18n index:getInvolved_description
+            a.btn-block(href=intlbase("event/")): :i18n index:eventInfo
+          .col-md-4: .card.shadow-sm.mb-4.h-100: .card-body
+            h4.text-center: :i18n index:newcomersGuide
+            p: :i18n index:callToAction
+            a.btn-block(href=intlbase("novice/")): :i18n index:newcomersGuide
           .col-md-4: .card.shadow-sm.mb-4.h-100: .card-body
             h4.text-center: :i18n index:donate
             p: :i18n index:donateBlurb
             a.btn-block(href="https://ocf.neticrm.tw/civicrm/contribute/transact?reset=1&id=30&_ga=2.218722001.93807760.1535621686-361420765.1511415990" target="_blank"): :i18n index:donateLink
-          .col-md-4: .card.shadow-sm.mb-4.h-100: .card-body
-            h4.text-center: :i18n index:propose
-            p: :i18n index:proposeBlurb
-            a.btn-block(href="https://grants.g0v.tw" target="_blank"): :i18n index:proposeLink
-          .col-md-4: .card.shadow-sm.mb-4.h-100: .card-body
-            h4.text-center: :i18n index:organize
-            p: :i18n index:organizeBlurb
-            a.btn-block(href="http://g0v.network" target="_blank"): :i18n index:organizeLink
         
-        h3: :i18n index:moreInfo
-        p
-          :i18n index:callToAction
-          | 
-          a(href=intlbase("novice/")): :i18n index:newcomersGuideLinkText
-          :i18n index:baam
-
     .d-none.d-md-block(style="min-width:10em"): .sticky.ml-4.pl-4.pt-4.border-left.border-danger
       br
       .mb-4
         .text-danger.clickable(data-scrollto="#news"): :i18n nav:latest
-      .mb-4
-        a.clickable.d-block(href="#",data-scrollto="#more"): :i18n nav:more
-        a.clickable.d-block(href="#",data-scrollto="#projects"): :i18n nav:projects
-        a.clickable.d-block(href="#",data-scrollto="#participate"): :i18n nav:join
       .mb-4
         a.clickable.d-block(href=intlbase("/manifesto/" + i18n.language())): :i18n nav:manifesto
         a.clickable.d-block(href=intlbase("/g0vernance/")): :i18n nav:g0vernance

--- a/web/src/pug/index.pug
+++ b/web/src/pug/index.pug
@@ -25,7 +25,7 @@ block body
         hr
         .text-center
           .btn.btn-outline-danger.mr-1.mb-2(data-scrollto="#projects"): :i18n index:projectList
-          .btn.btn-outline-danger.mr-1.mb-2(data-scrollto="#participate"): :i18n index:howToJoin
+          a.btn.btn-outline-danger.mr-1.mb-2(href=intlbase("novice/")): :i18n index:howToJoin
           a.btn.btn-outline-danger.mb-2(href=intlbase("/manifesto/" + i18n.language()),rol="button"): :i18n index:manifesto
 
   .w-1024.px-2.px-lg-4.mx-auto.rwd.d-flex


### PR DESCRIPTION
# 修改項目

1. 首頁移除 [了解更多](https://g0v.tw/#)、[成果列表](https://g0v.tw/#)、[如何參與](https://g0v.tw/#) 區塊
+ 舊版
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/50b93af0-6178-452c-8a2e-bb50feb359f0">

+ 新版
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/1a888f33-924a-4d01-91a0-9257e7f8218c">

2. 調整「活動資訊」、「新手指南」按鈕樣式，移除「常見問題」按鈕，增加「現在就捐款」說明及按鈕
+ 舊版
<img width="490" alt="image" src="https://github.com/user-attachments/assets/1bff25dc-58a3-49d4-a8bd-e9fdc155f1d3">

+ 新版
<img width="835" alt="image" src="https://github.com/user-attachments/assets/9dec88eb-45fa-4010-9520-8e5cf738b280">
